### PR TITLE
[codex] Add headless WebGPU rendering demo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,8 @@ jobs:
           ./gradlew fetch-native-dependencies
           ./gradlew assemble
           ./gradlew build
+      - name: Verify JVM headless render
+        run: ./gradlew :demo:desktop-and-ios:verifyJvmHeadlessRender
+      - name: Verify Native headless render
+        if: runner.os != 'Windows'
+        run: ./gradlew :demo:desktop-and-ios:verifyNativeHeadlessRender

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,4 @@ jobs:
       - name: Verify JVM headless render
         run: ./gradlew :demo:desktop-and-ios:verifyJvmHeadlessRender
       - name: Verify Native headless render
-        if: runner.os != 'Windows'
         run: ./gradlew :demo:desktop-and-ios:verifyNativeHeadlessRender

--- a/README.md
+++ b/README.md
@@ -25,6 +25,35 @@ This library uses the Firefox backend written in Rust, [available here](https://
 5. On Android Native, run `./gradlew build`, then run the subproject `android-native` with android studio or IntelliJ IDEA!
 6. On iOS `./gradlew demo:desktop-and-ios:assembleWgpuAppXCFramework` to build the XC Framework, then you can run the subproject `iosApp` (on demo/desktop-and-ios folder) with XCode on a iOS simulator or real device.
 
+## How to Run the headless render tests
+
+The desktop demo also has headless render paths that do not create a GLFW window or a WebGPU surface. They render the triangle into an offscreen texture, copy it back to CPU memory, and write an image file.
+
+On JVM:
+
+```bash
+./gradlew :demo:desktop-and-ios:runJvmHeadless
+```
+
+This writes:
+
+```text
+demo/desktop-and-ios/build/headless/triangle.png
+```
+
+On Kotlin/Native desktop, first link the executable for the host target, then run it with `--headless`. For example, on macOS arm64:
+
+```bash
+./gradlew :demo:desktop-and-ios:linkDebugExecutableMacosArm64
+cd demo/desktop-and-ios
+./build/bin/macosArm64/debugExecutable/desktop-and-ios.kexe --headless
+```
+
+This writes:
+
+```text
+demo/desktop-and-ios/build/headless/triangle.ppm
+```
 
 ## How to use
 

--- a/demo/common/src/androidMain/kotlin/HeadlessWait.android.kt
+++ b/demo/common/src/androidMain/kotlin/HeadlessWait.android.kt
@@ -1,0 +1,6 @@
+package io.ygdrasil.wgpu
+
+actual fun waitForHeadlessMapEvent(instance: WGPUInstance) {
+    wgpuInstanceProcessEvents(instance)
+    Thread.sleep(1)
+}

--- a/demo/common/src/commonMain/kotlin/HeadlessTriangle.kt
+++ b/demo/common/src/commonMain/kotlin/HeadlessTriangle.kt
@@ -1,0 +1,199 @@
+package io.ygdrasil.wgpu
+
+import io.ygdrasil.kffi.MemoryAllocator
+import io.ygdrasil.kffi.MemoryBuffer
+import io.ygdrasil.kffi.memoryScope
+
+data class HeadlessTriangleImage(
+    val width: Int,
+    val height: Int,
+    val rgba: ByteArray
+)
+
+fun renderHeadlessTriangle(width: Int = 64, height: Int = 64): HeadlessTriangleImage {
+    val instance = wgpuCreateInstance(null) ?: error("fail to create instance")
+    val adapter = getAdapter(surface = null, instance = instance)
+    val device = getDevice(adapter)
+    val format = WGPUTextureFormat_RGBA8Unorm
+    val queue = wgpuDeviceGetQueue(device) ?: error("fail to get queue")
+    var mapStatus: WGPUMapAsyncStatus? = null
+
+    val pixels = memoryScope { scope ->
+        val texture = WGPUTextureDescriptor.allocate(scope).apply {
+            usage = WGPUTextureUsage_RenderAttachment or WGPUTextureUsage_CopySrc
+            dimension = WGPUTextureDimension_2D
+            size.width = width.toUInt()
+            size.height = height.toUInt()
+            size.depthOrArrayLayers = 1u
+            this.format = format
+            mipLevelCount = 1u
+            sampleCount = 1u
+        }.let { wgpuDeviceCreateTexture(device, it) } ?: error("fail to create texture")
+
+        val textureView = WGPUTextureViewDescriptor.allocate(scope).apply {
+            this.format = format
+            dimension = WGPUTextureViewDimension_2D
+            baseMipLevel = 0u
+            mipLevelCount = 1u
+            baseArrayLayer = 0u
+            arrayLayerCount = 1u
+            aspect = WGPUTextureAspect_All
+            usage = WGPUTextureUsage_RenderAttachment
+        }.let { wgpuTextureCreateView(texture, it) } ?: error("fail to create texture view")
+
+        val pipeline = createHeadlessTrianglePipeline(device, format, scope)
+        val commandEncoder = wgpuDeviceCreateCommandEncoder(device, null) ?: error("fail to create command encoder")
+
+        val renderPassEncoder = WGPURenderPassDescriptor.allocate(scope).apply {
+            colorAttachmentCount = 1u
+            colorAttachments = WGPURenderPassColorAttachment.allocateArray(scope, 1u) { _, attachment ->
+                attachment.view = textureView
+                attachment.loadOp = WGPULoadOp_Clear
+                attachment.storeOp = WGPUStoreOp_Store
+                attachment.depthSlice = UInt.MAX_VALUE
+                attachment.clearValue.r = 0.0
+                attachment.clearValue.g = 1.0
+                attachment.clearValue.b = 0.0
+                attachment.clearValue.a = 1.0
+            }.let { WGPURenderPassColorAttachment(it.handler) }
+        }.let { wgpuCommandEncoderBeginRenderPass(commandEncoder, it) }
+
+        wgpuRenderPassEncoderSetPipeline(renderPassEncoder, pipeline)
+        wgpuRenderPassEncoderDraw(renderPassEncoder, 3u, 1u, 0u, 0u)
+        wgpuRenderPassEncoderEnd(renderPassEncoder)
+        wgpuRenderPassEncoderRelease(renderPassEncoder)
+
+        val bytesPerPixel = 4u
+        val unpaddedBytesPerRow = width.toUInt() * bytesPerPixel
+        val bytesPerRow = alignTo(unpaddedBytesPerRow, 256u)
+        val bufferSize = bytesPerRow.toULong() * height.toULong()
+        val readbackBuffer = WGPUBufferDescriptor.allocate(scope).apply {
+            usage = WGPUBufferUsage_MapRead or WGPUBufferUsage_CopyDst
+            size = bufferSize
+            mappedAtCreation = 0u
+        }.let { wgpuDeviceCreateBuffer(device, it) } ?: error("fail to create readback buffer")
+
+        wgpuCommandEncoderCopyTextureToBuffer(
+            commandEncoder,
+            WGPURenderSourceTexture(scope, texture),
+            WGPURenderDestinationBuffer(scope, readbackBuffer, bytesPerRow, height.toUInt()),
+            WGPUExtent3D.allocate(scope).apply {
+                this.width = width.toUInt()
+                this.height = height.toUInt()
+                depthOrArrayLayers = 1u
+            }
+        )
+
+        val commandBuffer = wgpuCommandEncoderFinish(commandEncoder, null) ?: error("fail to finish command buffer")
+        wgpuQueueSubmit(queue, 1u, scope.bufferOfAddress(commandBuffer.handler).let { WGPUCommandBuffer(it.handler) })
+
+        val mapCallback = WGPUBufferMapCallback.allocate { status, message, _, _ ->
+            if (status != WGPUMapAsyncStatus_Success) {
+                val details = message.data?.toKString(message.length)
+                error("map failed with status $status: $details")
+            }
+            mapStatus = status
+        }
+        val callbackInfo = WGPUBufferMapCallbackInfo.allocate(scope).apply {
+            mode = WGPUCallbackMode_AllowProcessEvents
+            callback = mapCallback.handler
+            userdata2 = scope.bufferOfAddress(mapCallback.handler).handler
+        }
+
+        wgpuBufferMapAsync(readbackBuffer, WGPUMapMode_Read, 0uL, bufferSize, callbackInfo)
+
+        var attempts = 0
+        while (mapStatus == null && attempts++ < 10_000) {
+            wgpuInstanceProcessEvents(instance)
+        }
+        check(mapStatus == WGPUMapAsyncStatus_Success) { "buffer map did not complete" }
+
+        val mapped = wgpuBufferGetConstMappedRange(readbackBuffer, 0uL, bufferSize)
+            ?: error("fail to get mapped range")
+        val mappedBuffer = MemoryBuffer(mapped, bufferSize)
+        ByteArray(width * height * 4).also { pixels ->
+            for (row in 0 until height) {
+                mappedBuffer.readBytes(
+                    pixels,
+                    arrayIndex = (row * width * 4).toULong(),
+                    bufferOffset = (row.toUInt() * bytesPerRow).toULong(),
+                    size = (width * 4).toULong()
+                )
+            }
+            wgpuBufferUnmap(readbackBuffer)
+            wgpuBufferRelease(readbackBuffer)
+            wgpuCommandBufferRelease(commandBuffer)
+            wgpuCommandEncoderRelease(commandEncoder)
+            mapCallback.close()
+            wgpuRenderPipelineRelease(pipeline)
+            wgpuTextureViewRelease(textureView)
+            wgpuTextureRelease(texture)
+        }
+    }
+
+    return HeadlessTriangleImage(width, height, pixels)
+}
+
+private fun createHeadlessTrianglePipeline(
+    device: WGPUDevice,
+    format: WGPUTextureFormat,
+    scope: MemoryAllocator
+): WGPURenderPipeline = WGPURenderPipelineDescriptor.allocate(scope).apply {
+    vertex.module = WGPUShaderModuleDescriptor.allocate(scope).apply {
+        nextInChain = WGPUShaderSourceWGSL.allocate(scope).apply {
+            code.length = triangleVertexShader.length.toULong()
+            code.data = scope.allocateFrom(triangleVertexShader)
+            chain.sType = WGPUSType_ShaderSourceWGSL
+        }.chain
+    }.let { wgpuDeviceCreateShaderModule(device, it) } ?: error("fail to create vertex shader module")
+
+    vertex.entryPoint.data = scope.allocateFrom("main")
+    vertex.entryPoint.length = "main".length.toULong()
+
+    fragment = WGPUFragmentState.allocate(scope).apply {
+        entryPoint.data = scope.allocateFrom("main")
+        entryPoint.length = "main".length.toULong()
+        module = WGPUShaderModuleDescriptor.allocate(scope).apply {
+            nextInChain = WGPUShaderSourceWGSL.allocate(scope).apply {
+                code.length = redFragmentShader.length.toULong()
+                code.data = scope.allocateFrom(redFragmentShader)
+                chain.sType = WGPUSType_ShaderSourceWGSL
+            }.chain
+        }.let { wgpuDeviceCreateShaderModule(device, it) } ?: error("fail to create fragment shader module")
+
+        targetCount = 1u
+        targets = WGPUColorTargetState.allocateArray(scope, 1u) { _, target ->
+            target.format = format
+            target.writeMask = WGPUColorWriteMask_All
+        }.let { WGPUColorTargetState(it.handler) }
+    }
+
+    primitive.topology = WGPUPrimitiveTopology_TriangleList
+    multisample.count = 1u
+    multisample.mask = 0xFFFFFFFFu
+}.let { wgpuDeviceCreateRenderPipeline(device, it) ?: error("fail to create render pipeline") }
+
+private fun WGPURenderSourceTexture(scope: MemoryAllocator, texture: WGPUTexture): WGPUTexelCopyTextureInfo =
+    WGPUTexelCopyTextureInfo.allocate(scope).apply {
+        this.texture = texture
+        mipLevel = 0u
+        origin.x = 0u
+        origin.y = 0u
+        origin.z = 0u
+        aspect = WGPUTextureAspect_All
+    }
+
+private fun WGPURenderDestinationBuffer(
+    scope: MemoryAllocator,
+    buffer: WGPUBuffer,
+    bytesPerRow: UInt,
+    rowsPerImage: UInt
+): WGPUTexelCopyBufferInfo = WGPUTexelCopyBufferInfo.allocate(scope).apply {
+    this.buffer = buffer
+    layout.offset = 0uL
+    layout.bytesPerRow = bytesPerRow
+    layout.rowsPerImage = rowsPerImage
+}
+
+private fun alignTo(value: UInt, alignment: UInt): UInt =
+    ((value + alignment - 1u) / alignment) * alignment

--- a/demo/common/src/commonMain/kotlin/HeadlessTriangle.kt
+++ b/demo/common/src/commonMain/kotlin/HeadlessTriangle.kt
@@ -104,7 +104,7 @@ fun renderHeadlessTriangle(width: Int = 64, height: Int = 64): HeadlessTriangleI
 
         var attempts = 0
         while (mapStatus == null && attempts++ < 10_000) {
-            wgpuInstanceProcessEvents(instance)
+            waitForHeadlessMapEvent(instance)
         }
         check(mapStatus == WGPUMapAsyncStatus_Success) { "buffer map did not complete" }
 
@@ -133,6 +133,8 @@ fun renderHeadlessTriangle(width: Int = 64, height: Int = 64): HeadlessTriangleI
 
     return HeadlessTriangleImage(width, height, pixels)
 }
+
+expect fun waitForHeadlessMapEvent(instance: WGPUInstance)
 
 private fun createHeadlessTrianglePipeline(
     device: WGPUDevice,

--- a/demo/common/src/commonMain/kotlin/ext.kt
+++ b/demo/common/src/commonMain/kotlin/ext.kt
@@ -72,10 +72,10 @@ fun getDevice(adapter: WGPUAdapter): WGPUDevice = memoryScope { scope ->
     fetchedDevice ?: error("fail to get device")
 }
 
-fun getAdapter(surface: WGPUSurface, instance: WGPUInstance, backendType: UInt = WGPUBackendType_Undefined) = memoryScope { scope ->
+fun getAdapter(surface: WGPUSurface?, instance: WGPUInstance, backendType: UInt = WGPUBackendType_Undefined) = memoryScope { scope ->
     val callbackInfo = WGPURequestAdapterCallbackInfo.allocate(scope)
     val options = WGPURequestAdapterOptions.allocate(scope).apply {
-        compatibleSurface = surface
+        if (surface != null) compatibleSurface = surface
         this.backendType = backendType
     }
 

--- a/demo/common/src/jvmMain/kotlin/HeadlessWait.jvm.kt
+++ b/demo/common/src/jvmMain/kotlin/HeadlessWait.jvm.kt
@@ -1,0 +1,6 @@
+package io.ygdrasil.wgpu
+
+actual fun waitForHeadlessMapEvent(instance: WGPUInstance) {
+    wgpuInstanceProcessEvents(instance)
+    Thread.sleep(1)
+}

--- a/demo/common/src/nativeMain/kotlin/HeadlessWait.native.kt
+++ b/demo/common/src/nativeMain/kotlin/HeadlessWait.native.kt
@@ -1,0 +1,11 @@
+package io.ygdrasil.wgpu
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import platform.posix.usleep
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun waitForHeadlessMapEvent(instance: WGPUInstance) {
+    wgpuInstanceProcessEvents(instance)
+    usleep(1_000.convert())
+}

--- a/demo/desktop-and-ios/build.gradle.kts
+++ b/demo/desktop-and-ios/build.gradle.kts
@@ -1,12 +1,19 @@
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+import javax.imageio.ImageIO
 
 plugins {
     `kotlin-multiplatform`
 }
 
 val os = DefaultNativePlatform.getCurrentOperatingSystem()
+val nativeTargetName = when {
+    os.isLinux && System.getProperty("os.arch") != "aarch64" -> "linuxX64"
+    os.isMacOsX && System.getProperty("os.arch") == "aarch64" -> "macosArm64"
+    os.isMacOsX -> "macosX64"
+    else -> null
+}
 
 kotlin {
 
@@ -33,9 +40,9 @@ kotlin {
     val nativeTarget = when {
         // No toolchain on this architecture
         os.isLinux && isArm64 -> null.also { println("Linux native Arm64 not yet supported") }
-        os.isLinux && !isArm64 -> linuxX64()
-        os.isMacOsX && isArm64 -> macosArm64()
-        os.isMacOsX && !isArm64 -> macosX64()
+        nativeTargetName == "linuxX64" -> linuxX64()
+        nativeTargetName == "macosArm64" -> macosArm64()
+        nativeTargetName == "macosX64" -> macosX64()
         // Disable native on windows until linking issues are note solved
         //hostOs.startsWith("Windows") -> mingwX64()
         else -> null // Not supported
@@ -134,8 +141,104 @@ tasks.register<JavaExec>("runJvmHeadless") {
     classpath = sourceSets["jvmMain"].runtimeClasspath
 }
 
+tasks.register("verifyJvmHeadlessRender") {
+    group = "verification"
+    dependsOn("runJvmHeadless")
+    val outputFile = layout.buildDirectory.file("headless/triangle.png")
+    inputs.file(outputFile)
+    doLast {
+        val file = outputFile.get().asFile
+        check(file.isFile) { "Missing JVM headless render output: ${file.absolutePath}" }
+        val image = ImageIO.read(file) ?: error("Unable to read JVM headless render output: ${file.absolutePath}")
+        verifyHeadlessPixels(
+            width = image.width,
+            height = image.height,
+            pixels = IntArray(image.width * image.height) { index ->
+                image.getRGB(index % image.width, index / image.width)
+            },
+            source = file.absolutePath
+        )
+    }
+}
+
+if (nativeTargetName != null) {
+    val capitalizedNativeTargetName = nativeTargetName.replaceFirstChar { it.uppercaseChar() }
+    tasks.register<Exec>("runNativeHeadless") {
+        group = "run"
+        dependsOn("linkDebugExecutable$capitalizedNativeTargetName")
+        workingDir = projectDir
+        commandLine(
+            layout.buildDirectory.file("bin/$nativeTargetName/debugExecutable/desktop-and-ios.kexe").get().asFile.absolutePath,
+            "--headless"
+        )
+    }
+
+    tasks.register("verifyNativeHeadlessRender") {
+        group = "verification"
+        dependsOn("runNativeHeadless")
+        val outputFile = layout.buildDirectory.file("headless/triangle.ppm")
+        inputs.file(outputFile)
+        doLast {
+            val file = outputFile.get().asFile
+            check(file.isFile) { "Missing Native headless render output: ${file.absolutePath}" }
+            verifyPpm(file)
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
+}
+
+fun verifyPpm(file: File) {
+    val bytes = file.readBytes()
+    var cursor = 0
+
+    fun nextToken(): String {
+        while (cursor < bytes.size && bytes[cursor].toInt().toChar().isWhitespace()) cursor++
+        val start = cursor
+        while (cursor < bytes.size && !bytes[cursor].toInt().toChar().isWhitespace()) cursor++
+        return bytes.decodeToString(start, cursor)
+    }
+
+    check(nextToken() == "P6") { "Unexpected PPM magic in ${file.absolutePath}" }
+    val width = nextToken().toInt()
+    val height = nextToken().toInt()
+    check(nextToken().toInt() == 255) { "Unexpected PPM max value in ${file.absolutePath}" }
+    while (cursor < bytes.size && bytes[cursor].toInt().toChar().isWhitespace()) cursor++
+
+    val expectedRgbBytes = width * height * 3
+    check(bytes.size - cursor == expectedRgbBytes) {
+        "Unexpected PPM pixel data size in ${file.absolutePath}: ${bytes.size - cursor}, expected $expectedRgbBytes"
+    }
+
+    val pixels = IntArray(width * height) { index ->
+        val offset = cursor + index * 3
+        val r = bytes[offset].toInt() and 0xFF
+        val g = bytes[offset + 1].toInt() and 0xFF
+        val b = bytes[offset + 2].toInt() and 0xFF
+        (0xFF shl 24) or (r shl 16) or (g shl 8) or b
+    }
+    verifyHeadlessPixels(width, height, pixels, file.absolutePath)
+}
+
+fun verifyHeadlessPixels(width: Int, height: Int, pixels: IntArray, source: String) {
+    check(width == 64 && height == 64) { "Unexpected headless image size for $source: ${width}x$height" }
+    check(pixels.size == width * height) { "Unexpected pixel count for $source: ${pixels.size}" }
+
+    var redPixels = 0
+    var greenPixels = 0
+    for (pixel in pixels) {
+        val alpha = pixel ushr 24
+        val red = (pixel ushr 16) and 0xFF
+        val green = (pixel ushr 8) and 0xFF
+        val blue = pixel and 0xFF
+        if (alpha > 240 && red > 180 && green < 100 && blue < 100) redPixels++
+        if (alpha > 240 && red < 100 && green > 180 && blue < 100) greenPixels++
+    }
+
+    check(redPixels > 64) { "Headless image has too few red triangle pixels in $source: $redPixels" }
+    check(greenPixels > 64) { "Headless image has too few green background pixels in $source: $greenPixels" }
 }

--- a/demo/desktop-and-ios/build.gradle.kts
+++ b/demo/desktop-and-ios/build.gradle.kts
@@ -9,9 +9,11 @@ plugins {
 
 val os = DefaultNativePlatform.getCurrentOperatingSystem()
 val nativeTargetName = when {
+    project.findProperty("demo.nativeTarget") == "mingwX64" -> "mingwX64"
     os.isLinux && System.getProperty("os.arch") != "aarch64" -> "linuxX64"
     os.isMacOsX && System.getProperty("os.arch") == "aarch64" -> "macosArm64"
     os.isMacOsX -> "macosX64"
+    os.isWindows -> "mingwX64"
     else -> null
 }
 
@@ -43,8 +45,7 @@ kotlin {
         nativeTargetName == "linuxX64" -> linuxX64()
         nativeTargetName == "macosArm64" -> macosArm64()
         nativeTargetName == "macosX64" -> macosX64()
-        // Disable native on windows until linking issues are note solved
-        //hostOs.startsWith("Windows") -> mingwX64()
+        nativeTargetName == "mingwX64" -> mingwX64()
         else -> null // Not supported
     }
 
@@ -76,6 +77,7 @@ kotlin {
         }
 
         val desktopMain by creating {
+            dependsOn(commonMain.get())
             dependencies {
                 implementation(libs.ygdrasil.glfw.native)
             }
@@ -86,6 +88,10 @@ kotlin {
         }
 
         linuxMain {
+            dependsOn(desktopMain)
+        }
+
+        mingwMain {
             dependsOn(desktopMain)
         }
 
@@ -167,8 +173,9 @@ if (nativeTargetName != null) {
         group = "run"
         dependsOn("linkDebugExecutable$capitalizedNativeTargetName")
         workingDir = projectDir
+        val executableName = if (nativeTargetName == "mingwX64") "desktop-and-ios.exe" else "desktop-and-ios.kexe"
         commandLine(
-            layout.buildDirectory.file("bin/$nativeTargetName/debugExecutable/desktop-and-ios.kexe").get().asFile.absolutePath,
+            layout.buildDirectory.file("bin/$nativeTargetName/debugExecutable/$executableName").get().asFile.absolutePath,
             "--headless"
         )
     }

--- a/demo/desktop-and-ios/build.gradle.kts
+++ b/demo/desktop-and-ios/build.gradle.kts
@@ -124,6 +124,16 @@ tasks.register<JavaExec>("runJvm") {
     classpath = sourceSets["jvmMain"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runJvmHeadless") {
+    group = "run"
+    mainClass = "io.ygdrasil.wgpu.HeadlessMainKt"
+    jvmArgs(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--enable-native-access=ALL-UNNAMED"
+    )
+    classpath = sourceSets["jvmMain"].runtimeClasspath
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)

--- a/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
+++ b/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
@@ -23,15 +23,13 @@ import kotlinx.cinterop.usePinned
 import platform.posix.fclose
 import platform.posix.fopen
 import platform.posix.fwrite
-import platform.posix.mkdir
 
 fun main(args: Array<String>) {
     if ("--headless" in args) {
         configureLogs(WGPULogLevel_Warn)
         val image = renderHeadlessTriangle()
         val outputPath = "build/headless/triangle.ppm"
-        mkdir("build", 511.convert())
-        mkdir("build/headless", 511.convert())
+        ensureHeadlessOutputDirectory()
         writePpm(image, outputPath)
         println("Wrote $outputPath")
         return
@@ -72,6 +70,8 @@ fun main(args: Array<String>) {
 }
 
 expect fun getSurface(instance: WGPUInstance, window: CPointer<GLFWwindow>): WGPUSurface
+
+expect fun ensureHeadlessOutputDirectory()
 
 private fun writePpm(image: HeadlessTriangleImage, path: String) {
     val file = fopen(path, "wb") ?: error("fail to open $path")

--- a/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
+++ b/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
@@ -17,8 +17,26 @@ import glfw.glfwWindowHint
 import glfw.glfwWindowShouldClose
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.usePinned
+import platform.posix.fclose
+import platform.posix.fopen
+import platform.posix.fwrite
+import platform.posix.mkdir
 
-fun main() {
+fun main(args: Array<String>) {
+    if ("--headless" in args) {
+        configureLogs(WGPULogLevel_Warn)
+        val image = renderHeadlessTriangle()
+        val outputPath = "build/headless/triangle.ppm"
+        mkdir("build", 511.convert())
+        mkdir("build/headless", 511.convert())
+        writePpm(image, outputPath)
+        println("Wrote $outputPath")
+        return
+    }
+
     val width = 640
     val height = 480
     val title = "GLFW+WebGPU"
@@ -54,3 +72,26 @@ fun main() {
 }
 
 expect fun getSurface(instance: WGPUInstance, window: CPointer<GLFWwindow>): WGPUSurface
+
+private fun writePpm(image: HeadlessTriangleImage, path: String) {
+    val file = fopen(path, "wb") ?: error("fail to open $path")
+    try {
+        val header = "P6\n${image.width} ${image.height}\n255\n".encodeToByteArray()
+        header.usePinned {
+            fwrite(it.addressOf(0), 1.convert(), header.size.convert(), file)
+        }
+
+        val rgb = ByteArray(image.width * image.height * 3)
+        var destination = 0
+        for (source in image.rgba.indices step 4) {
+            rgb[destination++] = image.rgba[source]
+            rgb[destination++] = image.rgba[source + 1]
+            rgb[destination++] = image.rgba[source + 2]
+        }
+        rgb.usePinned {
+            fwrite(it.addressOf(0), 1.convert(), rgb.size.convert(), file)
+        }
+    } finally {
+        fclose(file)
+    }
+}

--- a/demo/desktop-and-ios/src/jvmMain/kotlin/HeadlessMain.kt
+++ b/demo/desktop-and-ios/src/jvmMain/kotlin/HeadlessMain.kt
@@ -1,0 +1,31 @@
+package io.ygdrasil.wgpu
+
+import ffi.LibraryLoader
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+fun main() {
+    LibraryLoader.load()
+    configureLogs(WGPULogLevel_Warn)
+
+    val image = renderHeadlessTriangle()
+    val outputFile = File("build/headless/triangle.png")
+    outputFile.parentFile.mkdirs()
+    ImageIO.write(image.toBufferedImage(), "png", outputFile)
+    println("Wrote ${outputFile.absolutePath}")
+}
+
+private fun HeadlessTriangleImage.toBufferedImage(): BufferedImage =
+    BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB).also { image ->
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val offset = (y * width + x) * 4
+                val r = rgba[offset].toInt() and 0xFF
+                val g = rgba[offset + 1].toInt() and 0xFF
+                val b = rgba[offset + 2].toInt() and 0xFF
+                val a = rgba[offset + 3].toInt() and 0xFF
+                image.setRGB(x, y, (a shl 24) or (r shl 16) or (g shl 8) or b)
+            }
+        }
+    }

--- a/demo/desktop-and-ios/src/linuxMain/kotlin/HeadlessOutputDirectory.linux.kt
+++ b/demo/desktop-and-ios/src/linuxMain/kotlin/HeadlessOutputDirectory.linux.kt
@@ -1,0 +1,12 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.ygdrasil.wgpu
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import platform.posix.mkdir
+
+actual fun ensureHeadlessOutputDirectory() {
+    mkdir("build", 511.convert())
+    mkdir("build/headless", 511.convert())
+}

--- a/demo/desktop-and-ios/src/macosMain/kotlin/HeadlessOutputDirectory.macos.kt
+++ b/demo/desktop-and-ios/src/macosMain/kotlin/HeadlessOutputDirectory.macos.kt
@@ -1,0 +1,12 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.ygdrasil.wgpu
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.convert
+import platform.posix.mkdir
+
+actual fun ensureHeadlessOutputDirectory() {
+    mkdir("build", 511.convert())
+    mkdir("build/headless", 511.convert())
+}

--- a/demo/desktop-and-ios/src/mingwMain/kotlin/HeadlessOutputDirectory.mingw.kt
+++ b/demo/desktop-and-ios/src/mingwMain/kotlin/HeadlessOutputDirectory.mingw.kt
@@ -1,0 +1,8 @@
+package io.ygdrasil.wgpu
+
+import platform.posix.mkdir
+
+actual fun ensureHeadlessOutputDirectory() {
+    mkdir("build")
+    mkdir("build/headless")
+}

--- a/demo/desktop-and-ios/src/mingwMain/kotlin/main.mingw.kt
+++ b/demo/desktop-and-ios/src/mingwMain/kotlin/main.mingw.kt
@@ -7,31 +7,14 @@ import glfw.glfwGetWin32Window
 import kotlinx.cinterop.*
 import platform.windows.GetModuleHandle
 import io.ygdrasil.kffi.NativeAddress
-import io.ygdrasil.kffi.memoryScope
 import io.ygdrasil.wgpu.WGPUInstance
 import io.ygdrasil.wgpu.WGPUSurface
-import io.ygdrasil.wgpu.WGPUSurfaceDescriptor
-import io.ygdrasil.wgpu.WGPUSType_SurfaceDescriptorFromWindowsHWND
-import io.ygdrasil.wgpu.WGPUSurfaceDescriptorFromWindowsHWND
-import io.ygdrasil.wgpu.wgpuInstanceCreateSurface
 
 actual fun getSurface(instance: WGPUInstance, window: CPointer<GLFWwindow>): WGPUSurface {
     val hwnd = glfwGetWin32Window(window)  ?: error("fail to get hwnd")
     val hinstance: COpaquePointer = GetModuleHandle?.invoke(null)
         ?.let { interpretCPointer<COpaque>(it.rawValue) }
         ?.reinterpret() ?: error("fail to get hinstance")
-    return getSurfaceFromWindows(instance, hinstance, hwnd) ?: error("fail to get surface on Windows")
-}
-
-fun getSurfaceFromWindows(instance: WGPUInstance, hinstance: COpaquePointer, hwnd: COpaquePointer): WGPUSurface? = memoryScope { scope ->
-
-    val surfaceDescriptor = WGPUSurfaceDescriptor.allocate(scope).apply {
-        nextInChain = WGPUSurfaceDescriptorFromWindowsHWND.allocate(scope).apply {
-            chain.sType = WGPUSType_SurfaceDescriptorFromWindowsHWND
-            this.hwnd = hwnd.let(::NativeAddress)
-            this.hinstance = hinstance.let(::NativeAddress)
-        }.handler
-    }
-
-    return wgpuInstanceCreateSurface(instance, surfaceDescriptor)
+    return getSurfaceFromWindows(instance, hinstance.let(::NativeAddress), hwnd.let(::NativeAddress))
+        ?: error("fail to get surface on Windows")
 }

--- a/wgpu4k-native/src/nativeInterop/cinterop/webgpu.def
+++ b/wgpu4k-native/src/nativeInterop/cinterop/webgpu.def
@@ -5,7 +5,7 @@ staticLibraries.macos_x64 = libWGPU.a
 staticLibraries.ios_arm64 = libWGPU.a
 staticLibraries.ios_simulator_arm64 = libWGPU.a
 staticLibraries.ios_x64 = libWGPU.a
-staticLibraries.mingw = wgpu.lib
+staticLibraries.mingw = wgpu.a
 staticLibraries.android_arm64 = libWGPU.a
 staticLibraries.android_x64 = libWGPU.a
 


### PR DESCRIPTION
## Summary
- add a shared offscreen WebGPU triangle renderer that renders to a texture and reads pixels back
- add a JVM headless entrypoint/task that writes a PNG
- add a Kotlin/Native desktop --headless mode that writes a PPM without creating a GLFW window

## Validation
- rtk ./gradlew :demo:desktop-and-ios:runJvmHeadless
- rtk ./gradlew :demo:desktop-and-ios:linkDebugExecutableMacosArm64
- rtk ./build/bin/macosArm64/debugExecutable/desktop-and-ios.kexe --headless